### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/openshift.yml
+++ b/.github/workflows/openshift.yml
@@ -79,6 +79,10 @@ jobs:
     name: Build and deploy to OpenShift
     runs-on: ubuntu-latest
     environment: production
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
 
     outputs:
       ROUTE: ${{ steps.deploy-and-expose.outputs.route }}


### PR DESCRIPTION
Potential fix for [https://github.com/karimshaban01/adventurepts/security/code-scanning/1](https://github.com/karimshaban01/adventurepts/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the job level for the `openshift-ci-cd` job. This block will explicitly define the minimum permissions required for the job to function correctly. Based on the operations performed in the workflow, the following permissions are needed:
- `contents: read` to allow the workflow to read repository contents.
- `packages: write` to push container images to the GitHub Container Registry (GHCR).
- `id-token: write` to fetch an OpenID Connect (OIDC) token if required by the actions.

The `permissions` block will be added directly under the `openshift-ci-cd` job definition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
